### PR TITLE
Fix import statement.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           PATH: /usr/local/bin:/opt/cmake/bin:/opt/spicy/bin:/opt/zeek/bin:/opt/zeek/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         run: |
+          git config --global --add safe.directory $PWD
           git clean -fd
           eval $(zkg env)
           echo Y | zkg -vvvvv install .

--- a/analyzer/zeek_analyzer.spicy
+++ b/analyzer/zeek_analyzer.spicy
@@ -2,8 +2,7 @@
 
 module Zeek_DHCP;
 
-import DHCP from protocols;
-# import DHCP;
+import DHCP;
 import zeek;
 
 on DHCP::Message::%done {


### PR DESCRIPTION
The Zeek-specific part of the analyzers imported the DHCP module with a
non-existing path. This was incorrect ever since this analyzer was moved
out of Spicy where the path existed into zeek/spicy-analyzers, and then
also when it got moved to its own plugin. It appears this only worked
because Spicy did not handle import statements with scopes correctly
which (for at least what is happening here) is not the case anymore once
zeek/spicy#1187 is fixed.

This patch uses an unscoped import.