### PR TITLE
Use symbols from `spicy` instead of `hilti` runtime library.

### DIFF
--- a/analyzer/analyzer.spicy
+++ b/analyzer/analyzer.spicy
@@ -2,6 +2,8 @@
 
 module DHCP;
 
+import spicy;
+
 # RFC-2131: DHCP message, Table 1.
 public type Message = unit {
     op: uint8 &convert=Opcode($$);
@@ -138,7 +140,7 @@ type Option = unit {
         }
         OptionCode::MESSAGE -> {
             len : uint8;
-            message: bytes &size=self.len &convert=$$.decode(hilti::Charset::ASCII);
+            message: bytes &size=self.len &convert=$$.decode(spicy::Charset::ASCII);
         }
         OptionCode::MAXIMUM_DHCP_MESSAGE_SIZE -> {
             : uint8;

--- a/analyzer/zeek_analyzer.spicy
+++ b/analyzer/zeek_analyzer.spicy
@@ -3,6 +3,7 @@
 module Zeek_DHCP;
 
 import DHCP;
+import spicy;
 import zeek;
 
 on DHCP::Message::%done {
@@ -161,7 +162,7 @@ public function create_options(msg: DHCP::Message):
             class_identifier = option.class_identifier;
 
         if (option?.user_class)
-            user_class = option.user_class.decode(hilti::Charset::ASCII);
+            user_class = option.user_class.decode(spicy::Charset::ASCII);
     }
 
     return (


### PR DESCRIPTION
Previously Spicy would allow references to `hilti`, even though names from `spicy` should have been used. The most recent development version of Spicy got more strict here, so the code as written is now rejected.

This patch fixes the Spicy code to use symbols from `spicy` instead of `hilti`. We also add previously implicitly available imports.