### PR TITLE
Remove port usage in evt file.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,8 +10,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - zeek:5.0
-          - zeek:6.0
+          - zeek:7.0
           - zeek-dev:latest
 
       fail-fast: false

--- a/analyzer/__load__.zeek
+++ b/analyzer/__load__.zeek
@@ -1,2 +1,0 @@
-@load-sigs ./dpd.sig
-@load ./main

--- a/analyzer/analyzer.evt
+++ b/analyzer/analyzer.evt
@@ -2,8 +2,6 @@
 
 protocol analyzer spicy::DHCP over UDP:
     parse with DHCP::Message,
-    port 67/udp,
-    port 68/udp,
     replaces DHCP;
 
 import Zeek_DHCP;

--- a/analyzer/dpd.sig
+++ b/analyzer/dpd.sig
@@ -1,9 +1,0 @@
-# Copyright (c) 2021 by the Zeek Project. See LICENSE for details.
-
-# Signatures are copied from Zeek.
-
-signature spicy_dhcp_cookie {
-  ip-proto == udp
-  payload /^.{236}\x63\x82\x53\x63/
-  enable "spicy_DHCP"
-}

--- a/analyzer/main.zeek
+++ b/analyzer/main.zeek
@@ -1,3 +1,0 @@
-# TODO: Define Zeek-side records or functions you want to provide with your plugin.
-
-module Message;


### PR DESCRIPTION
This has been removed in Zeek 7.1. Zeek's base scripts will register the replaced analyzer.