### PR TITLE
Move from legacy vector element attribute syntax to more boring version

### DIFF
--- a/analyzer/analyzer.spicy
+++ b/analyzer/analyzer.spicy
@@ -76,19 +76,19 @@ type Option = unit {
         }
         OptionCode::ROUTER -> {
             len: uint8;
-            routers: addr[self.len/4] &ipv4; # `len` is always a multiple of 4.
+            routers: (addr &ipv4)[self.len/4] ; # `len` is always a multiple of 4.
         }
         OptionCode::TIME_SERVER -> {
             len: uint8;
-            time_servers: addr[self.len/4] &ipv4; # `len` is always a multiple of 4.
+            time_servers: (addr &ipv4)[self.len/4] ; # `len` is always a multiple of 4.
         }
         OptionCode::NAME_SERVER -> {
             len: uint8;
-            name_servers: addr[self.len/4] &ipv4; # `len` is always a multiple of 4.
+            name_servers: (addr &ipv4)[self.len/4] ; # `len` is always a multiple of 4.
         }
         OptionCode::DOMAIN_NAME_SERVER -> {
             len: uint8;
-            domain_name_servers: addr[self.len/4] &ipv4; # `len` is always a multiple of 4.
+            domain_name_servers: (addr &ipv4)[self.len/4] ; # `len` is always a multiple of 4.
         }
         OptionCode::HOST_NAME -> {
             len: uint8;
@@ -108,7 +108,7 @@ type Option = unit {
         }
         OptionCode::NETWORK_TIME_PROTOCOL_SERVER -> {
             len: uint8;
-            network_time_protocol_servers: addr[self.len/4] &ipv4; # `len` is always a multiple of 4.
+            network_time_protocol_servers: (addr &ipv4)[self.len/4]; # `len` is always a multiple of 4.
         }
         OptionCode::VENDOR_SPECIFIC_INFORMATION -> {
             len : uint8;
@@ -116,7 +116,7 @@ type Option = unit {
         }
         OptionCode::NETBIOS_OVER_TCPIP_NAME_SERVER -> {
             len: uint8;
-            netbios_over_tcpip_name_servers: addr[self.len/4] &ipv4; # `len` is always a multiple of 4.
+            netbios_over_tcpip_name_servers: (addr &ipv4)[self.len/4] ; # `len` is always a multiple of 4.
         }
         OptionCode::REQUESTED_ADDRESS -> {
             : uint8;


### PR DESCRIPTION
The version used for parsing here was actually removed on Spicy's development version recently so is not supported there anymore; instead use the more straight-forward way to pass these attributes.