### PR TITLE
Clarify extraction of message type

### DIFF
--- a/analyzer/analyzer.spicy
+++ b/analyzer/analyzer.spicy
@@ -63,7 +63,7 @@ type HardwareType = enum {
 type Options = unit {
     : b"\x63\x82\x53\x63"; # Magic Cookie.
     options: Option[];
-};
+} &convert=self.options;
 
 # RFC-1533: DHCP Options.
 type Option = unit {

--- a/analyzer/analyzer.spicy
+++ b/analyzer/analyzer.spicy
@@ -61,7 +61,7 @@ type HardwareType = enum {
 
 # RFC-1497: BOOTP Vendor Information Format.
 type Options = unit {
-    : b"\x63\x82\x53\x63"; # Magic Cookie.
+    : skip b"\x63\x82\x53\x63"; # Magic Cookie.
     options: Option[];
 } &convert=self.options;
 
@@ -71,7 +71,7 @@ type Option = unit {
     switch ( self.code ) {
         OptionCode::PAD, OptionCode::END -> : void {}
         OptionCode::TIME_OFFSET -> {
-            : uint8;
+            : skip uint8;
             time_offset: int32;
         }
         OptionCode::ROUTER -> {
@@ -99,11 +99,11 @@ type Option = unit {
             domain_name: bytes &size=self.len &convert=$$.decode();
         }
         OptionCode::FORWARDING -> {
-            : uint8;
+            : skip uint8;
             forwarding: uint8;
         }
         OptionCode::BROADCAST_ADDRESS -> {
-            : uint8;
+            : skip uint8;
             broadcast_address: addr &ipv4;
         }
         OptionCode::NETWORK_TIME_PROTOCOL_SERVER -> {
@@ -119,19 +119,19 @@ type Option = unit {
             netbios_over_tcpip_name_servers: (addr &ipv4)[self.len/4] ; # `len` is always a multiple of 4.
         }
         OptionCode::REQUESTED_ADDRESS -> {
-            : uint8;
+            : skip uint8;
             requested_address: addr &ipv4;
         }
         OptionCode::IP_ADDRESS_LEASE_TIME -> {
-            : uint8;
+            : skip uint8;
             ip_address_lease_time: uint32;
         }
         OptionCode::MESSAGE_TYPE -> {
-            : uint8;
+            : skip uint8;
             message_type: uint8 &convert=MessageType($$);
         }
         OptionCode::SERVER_IDENTIFIER -> {
-            : uint8;
+            : skip uint8;
             server_identifier: addr &ipv4;
         }
         OptionCode::PARAMETER_REQUESTS -> {
@@ -143,15 +143,15 @@ type Option = unit {
             message: bytes &size=self.len &convert=$$.decode(spicy::Charset::ASCII);
         }
         OptionCode::MAXIMUM_DHCP_MESSAGE_SIZE -> {
-            : uint8;
+            : skip uint8;
             maximum_dhcp_message_size: uint16;
         }
         OptionCode::RENEWAL_TIME_VALUE -> {
-            : uint8;
+            : skip uint8;
             renewal_time_value: uint32;
         }
         OptionCode::REBIND_TIME_VALUE -> {
-            : uint8;
+            : skip uint8;
             rebind_time_value: uint32;
         }
         OptionCode::CLASS_IDENTIFIER -> {

--- a/analyzer/analyzer.spicy
+++ b/analyzer/analyzer.spicy
@@ -76,20 +76,21 @@ type Option = unit {
             time_offset: int32;
         }
         OptionCode::ROUTER -> {
-            len: uint8;
-            routers: (addr &ipv4)[self.len / 4]; # `len` is always a multiple of 4.
+            len: uint8 &requires=($$ % 4 == 0); # `len` is always a multiple of 4.
+            routers: (addr &ipv4)[self.len / 4];
         }
         OptionCode::TIME_SERVER -> {
-            len: uint8;
-            time_servers: (addr &ipv4)[self.len / 4]; # `len` is always a multiple of 4.
+            len: uint8 &requires=($$ % 4 == 0); # `len` is always a multiple of 4.
+            time_servers: (addr &ipv4)[self.len / 4];
         }
         OptionCode::NAME_SERVER -> {
             len: uint8;
-            name_servers: (addr &ipv4)[self.len / 4]; # `len` is always a multiple of 4.
+            len: uint8 &requires=($$ % 4 == 0); # `len` is always a multiple of 4.
+            name_servers: (addr &ipv4)[self.len / 4];
         }
         OptionCode::DOMAIN_NAME_SERVER -> {
-            len: uint8;
-            domain_name_servers: (addr &ipv4)[self.len / 4]; # `len` is always a multiple of 4.
+            len: uint8 &requires=($$ % 4 == 0); # `len` is always a multiple of 4.
+            domain_name_servers: (addr &ipv4)[self.len / 4];
         }
         OptionCode::HOST_NAME -> {
             len: uint8;
@@ -108,16 +109,16 @@ type Option = unit {
             broadcast_address: addr &ipv4;
         }
         OptionCode::NETWORK_TIME_PROTOCOL_SERVER -> {
-            len: uint8;
-            network_time_protocol_servers: (addr &ipv4)[self.len / 4]; # `len` is always a multiple of 4.
+            len: uint8 &requires=($$ % 4 == 0); # `len` is always a multiple of 4.
+            network_time_protocol_servers: (addr &ipv4)[self.len / 4];
         }
         OptionCode::VENDOR_SPECIFIC_INFORMATION -> {
             len: uint8;
             vendor_specific_information: bytes &size=self.len &convert=$$.decode();
         }
         OptionCode::NETBIOS_OVER_TCPIP_NAME_SERVER -> {
-            len: uint8;
-            netbios_over_tcpip_name_servers: (addr &ipv4)[self.len / 4]; # `len` is always a multiple of 4.
+            len: uint8 &requires=($$ % 4 == 0); # `len` is always a multiple of 4.
+            netbios_over_tcpip_name_servers:(addr &ipv4)[self.len / 4];
         }
         OptionCode::REQUESTED_ADDRESS -> {
             : skip uint8;
@@ -160,7 +161,7 @@ type Option = unit {
             class_identifier: bytes &size=self.len &convert=$$.decode();
         }
         OptionCode::CLIENT_IDENTIFIER -> {
-            len: uint8;
+            len: uint8 &requires=$$>0;
             client_type: uint8 &convert=HardwareType($$);
             client_identifier: bytes &size=(self.len - 1);
         }

--- a/analyzer/analyzer.spicy
+++ b/analyzer/analyzer.spicy
@@ -17,28 +17,28 @@ public type Message = unit {
     yiaddr: addr &ipv4;
     siaddr: addr &ipv4;
     giaddr: addr &ipv4;
-    chaddr: bytes &size=16;
+    chaddr_str: bytes &size=16 &convert=chaddr_bytes_to_string($$, self.hlen);
     sname: bytes &size=64 &convert=$$.split1(b"\0")[0].decode();
     file_n: bytes &size=128 &convert=$$.split1(b"\0")[0].decode();
     options: Options;
-
-    # Correct encoding for chaddr, the client hardware address
-    var chaddr_str: string;
-    on chaddr {
-        # TODO(bbannier): Perform this conversion on the fly as part of parsing
-        # `chaddr` once https://github.com/zeek/spicy/issues/1261 is fixed.
-
-        # Iterate up to hlen, the hardware address length given in the message
-        local i = 0;
-        while ( i < self.hlen ) {
-            if ( i > 0 ) {
-                self.chaddr_str = self.chaddr_str + ":";
-            }
-            self.chaddr_str = self.chaddr_str + ("%02x" % *self.chaddr.at(i));
-            ++i;
-        }
-    }
 };
+
+# Stringify hardware address.
+function chaddr_bytes_to_string(chaddr: bytes, hlen: uint8): string {
+    local chaddr_str: string;
+
+    # Iterate up to hlen.
+    local i = 0;
+    while (i < hlen) {
+        if (i > 0) {
+            chaddr_str = chaddr_str + ":";
+        }
+        chaddr_str = chaddr_str + ("%02x" % *chaddr.at(i));
+        ++i;
+    }
+
+    return chaddr_str;
+}
 
 # RFC-2131: DHCP message, Table 1, op.
 type Opcode = enum {

--- a/analyzer/analyzer.spicy
+++ b/analyzer/analyzer.spicy
@@ -43,7 +43,7 @@ function chaddr_bytes_to_string(chaddr: bytes, hlen: uint8): string {
 # RFC-2131: DHCP message, Table 1, op.
 type Opcode = enum {
     BOOTREQUEST = 0x01,
-    BOOTREPLY = 0x02
+    BOOTREPLY = 0x02,
 };
 
 # RFC-1700: Adress Resolution Protocol Parameters, Hardware Type.
@@ -56,7 +56,7 @@ type HardwareType = enum {
     IEEE_802_NETWORKS = 0x06,
     ARCNET = 0x07,
     HYPERCHANNEL = 0x08,
-    LANSTAR = 0x09
+    LANSTAR = 0x09,
 };
 
 # RFC-1497: BOOTP Vendor Information Format.
@@ -68,27 +68,28 @@ type Options = unit {
 # RFC-1533: DHCP Options.
 type Option = unit {
     code: uint8 &convert=OptionCode($$);
-    switch ( self.code ) {
-        OptionCode::PAD, OptionCode::END -> : void {}
+    switch (self.code) {
+        OptionCode::PAD,
+        OptionCode::END -> : void {}
         OptionCode::TIME_OFFSET -> {
             : skip uint8;
             time_offset: int32;
         }
         OptionCode::ROUTER -> {
             len: uint8;
-            routers: (addr &ipv4)[self.len/4] ; # `len` is always a multiple of 4.
+            routers: (addr &ipv4)[self.len / 4]; # `len` is always a multiple of 4.
         }
         OptionCode::TIME_SERVER -> {
             len: uint8;
-            time_servers: (addr &ipv4)[self.len/4] ; # `len` is always a multiple of 4.
+            time_servers: (addr &ipv4)[self.len / 4]; # `len` is always a multiple of 4.
         }
         OptionCode::NAME_SERVER -> {
             len: uint8;
-            name_servers: (addr &ipv4)[self.len/4] ; # `len` is always a multiple of 4.
+            name_servers: (addr &ipv4)[self.len / 4]; # `len` is always a multiple of 4.
         }
         OptionCode::DOMAIN_NAME_SERVER -> {
             len: uint8;
-            domain_name_servers: (addr &ipv4)[self.len/4] ; # `len` is always a multiple of 4.
+            domain_name_servers: (addr &ipv4)[self.len / 4]; # `len` is always a multiple of 4.
         }
         OptionCode::HOST_NAME -> {
             len: uint8;
@@ -108,15 +109,15 @@ type Option = unit {
         }
         OptionCode::NETWORK_TIME_PROTOCOL_SERVER -> {
             len: uint8;
-            network_time_protocol_servers: (addr &ipv4)[self.len/4]; # `len` is always a multiple of 4.
+            network_time_protocol_servers: (addr &ipv4)[self.len / 4]; # `len` is always a multiple of 4.
         }
         OptionCode::VENDOR_SPECIFIC_INFORMATION -> {
-            len : uint8;
+            len: uint8;
             vendor_specific_information: bytes &size=self.len &convert=$$.decode();
         }
         OptionCode::NETBIOS_OVER_TCPIP_NAME_SERVER -> {
             len: uint8;
-            netbios_over_tcpip_name_servers: (addr &ipv4)[self.len/4] ; # `len` is always a multiple of 4.
+            netbios_over_tcpip_name_servers: (addr &ipv4)[self.len / 4]; # `len` is always a multiple of 4.
         }
         OptionCode::REQUESTED_ADDRESS -> {
             : skip uint8;
@@ -139,7 +140,7 @@ type Option = unit {
             request_values: uint8[self.len] &convert=[OptionCode(x) for x in $$];
         }
         OptionCode::MESSAGE -> {
-            len : uint8;
+            len: uint8;
             message: bytes &size=self.len &convert=$$.decode(spicy::Charset::ASCII);
         }
         OptionCode::MAXIMUM_DHCP_MESSAGE_SIZE -> {
@@ -165,7 +166,7 @@ type Option = unit {
         }
         OptionCode::USER_CLASS -> {
             len: uint8;
-            user_class:bytes &size=self.len;
+            user_class: bytes &size=self.len;
         }
         * -> : UnparsedOption(self.code);
     };
@@ -173,7 +174,7 @@ type Option = unit {
 
 type OptionCode = enum {
     PAD = 0,
-    SUBNET_MASK = 1,         # TODO(bbannier): implement handling, see https://tools.ietf.org/html/rfc950.
+    SUBNET_MASK = 1, # TODO(bbannier): implement handling, see https://tools.ietf.org/html/rfc950.
     TIME_OFFSET = 2,
     ROUTER = 3,
     TIME_SERVER = 4,
@@ -198,20 +199,20 @@ type OptionCode = enum {
     CLASS_IDENTIFIER = 60,
     CLIENT_IDENTIFIER = 61,
     USER_CLASS = 77,
-    END = 255
+    END = 255,
 };
 
 type MessageType = enum {
     DISCOVER = 0x01,
-    OFFER    = 0x02,
-    REQUEST  = 0x03,
-    DECLINE  = 0x04,
-    ACK      = 0x05,
-    NAK      = 0x06,
-    RELEASE  = 0x07
+    OFFER = 0x02,
+    REQUEST = 0x03,
+    DECLINE = 0x04,
+    ACK = 0x05,
+    NAK = 0x06,
+    RELEASE = 0x07,
 };
 
 type UnparsedOption = unit(code: OptionCode) {
-    len: uint8 if ( code != OptionCode::PAD && code != OptionCode::END );
-    data: bytes &size=self.len if ( code != OptionCode::PAD && code != OptionCode::END );
+    len: uint8 if(code != OptionCode::PAD && code != OptionCode::END);
+    data: bytes &size=self.len if(code != OptionCode::PAD && code != OptionCode::END);
 };

--- a/analyzer/zeek_analyzer.spicy
+++ b/analyzer/zeek_analyzer.spicy
@@ -216,9 +216,10 @@ public function create_msg(msg: DHCP::Message):
     # Retrieve DHCP message type from options
     local m_type: DHCP::MessageType;
     for (option in msg.options.options) {
-        if (option?.message_type)
+        if (option?.message_type) {
             m_type = option.message_type;
-            break;  # Found Message Type option, stop loop
+            break; # Found Message Type option, stop loop
+        }
     }
 
     return (

--- a/analyzer/zeek_analyzer.spicy
+++ b/analyzer/zeek_analyzer.spicy
@@ -53,7 +53,7 @@ public function create_options(msg: DHCP::Message):
         time_servers: optional<vector<addr>>,
         name_servers: optional<vector<addr>>,
         ntp_servers: optional<vector<addr>>> {
-    local options = [cast<uint32>(option.code) for option in msg.options.options];
+    local options = [cast<uint32>(option.code) for option in msg.options];
 
     local requested_address: optional<addr>;
     local param_list: optional<vector<uint32>>;
@@ -79,7 +79,7 @@ public function create_options(msg: DHCP::Message):
     local class_identifier: optional<string>;
     local user_class: optional<string>;
 
-    for (option in msg.options.options) {
+    for (option in msg.options) {
         if (option?.requested_address)
             requested_address = option.requested_address;
 
@@ -215,7 +215,7 @@ public function create_msg(msg: DHCP::Message):
 
     # Retrieve DHCP message type from options
     local m_type: DHCP::MessageType;
-    for (option in msg.options.options) {
+    for (option in msg.options) {
         if (option?.message_type) {
             m_type = option.message_type;
             break; # Found Message Type option, stop loop


### PR DESCRIPTION
If a message declared multiple message types in its options we would
previously use the last type, even though originally our intention was
to use the first one (as was also suggested by the source code
indention).

This change fixes the code to have the intended behavior.